### PR TITLE
fix: update start scripts and improve NODE_ENV handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "type": "module",
   "scripts": {
     "test": "jest --maxWorkers=1",
-    "start:dev": "set NODE_ENV=development && nodemon",
-    "start:prod": "set NODE_ENV=production && nodemon src/app.js --legacy-watch",
+    "start:dev": "set NODE_ENV=development && nodemon --legacy-watch",
+    "start:prod": "set NODE_ENV=production && nodemon --legacy-watch",
     "lint": "eslint . --fix",
     "prepare": "husky install",
     "pre-commit": "lint-staged"

--- a/src/envSetup.js
+++ b/src/envSetup.js
@@ -6,7 +6,7 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
 export const loadEnvConfig = () => {
-  const NODE_ENV = process.env.NODE_ENV || 'development'
+  const NODE_ENV = process.env?.NODE_ENV?.trim() || 'development'
   const envFile = NODE_ENV === 'production' ? '.env.local' : '.env.test.local'
   const envPath = path.join(__dirname, '..', envFile)
   const result = dotenv.config({ path: envPath })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated development and production start scripts with legacy watch option
	- Improved environment configuration loading by adding optional chaining and trimming for `NODE_ENV`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->