### PR TITLE
Add manual cache clearing for languages, locations, and all cache (#376)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,52 @@ To run unit test open terminal and run `npm run test` in it.
   - All configuration is implemented via environment variable that is located inside
     `.env` file
 
+# Cache Clearing Functionality
+
+This project includes functionality for managing cache, specifically for:
+1. Clearing all cached data.
+2. Clearing cached data for languages.
+3. Clearing cached data for locations.
+
+## Commands
+
+You can use the following npm scripts to manually clear the cache:
+
+### 1. Clear All Cache
+To clear all cached data:
+```bash
+npm run clear:cache:all
+```
+This command will flush all cache entries from the system.
+
+### 2. Clear Languages Cache
+To clear only the cache related to languages:
+```bash
+npm run clear:cache:languages
+```
+This command will remove the cache entry for `languages` from the system.
+
+### 3. Clear Locations Cache
+To clear only the cache related to locations (countries and cities):
+```bash
+npm run clear:cache:locations
+```
+This command will:
+- Remove the cache entry for `countries`.
+- Remove all cache entries for cities, identified by keys with the prefix `cities_`.
+
+## Scheduled Cache Clearing
+The system also includes a scheduled task to automatically clear all cache every 24 hours at midnight (UTC). This is managed using `node-cron`.
+
+### Schedule Details:
+- **Time**: Midnight (00:00 UTC)
+- **Frequency**: Daily
+
+## Notes
+- Ensure that the `node-cache` module is properly configured in your project.
+- Use these commands carefully in production environments to avoid accidental data loss in the cache.
+
+
 ### Testing
 
 - Tests are implemented in the format of contract tests. We test services, controllers, middlewares, utils or subscriptions on the running application.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "start:dev": "cross-env NODE_ENV=development nodemon src/app.js",
     "start:prod": "cross-env NODE_ENV=production node src/app.js",
     "lint": "eslint . --fix",
-    "pre-commit": "lint-staged"
+    "pre-commit": "lint-staged",
+    "clear:cache:all": "node src/seed/manualClearCache.js all",
+    "clear:cache:languages": "node src/seed/manualClearCache.js languages",
+    "clear:cache:locations": "node src/seed/manualClearCache.js locations"
   },
   "author": "SoftServe ITA",
   "license": "ISC",

--- a/src/cron-jobs/clearCache.js
+++ b/src/cron-jobs/clearCache.js
@@ -2,15 +2,43 @@ import cron from 'node-cron'
 import cache from '#utils/cache.js'
 
 /**
- * Scheduled task to clear cache every 24 hours.
+ * Scheduled task to clear all cache every 24 hours.
  * Runs at midnight (00:00) UTC daily.
  */
 export const clearCache = cron.schedule(
   '0 0 * * *',
   () => {
-    console.log('🗑️ Clearing cache...')
+    console.log('🗑️ Clearing all cache automatically...')
     cache.flushAll()
-    console.log('✅ Cache cleared successfully')
+    console.log('✅ All cache cleared successfully (automatically).')
   },
   { scheduled: false }
 )
+
+/**
+ * Manual clearing of all cache.
+ */
+export const clearCacheManually = async () => {
+  console.log('🗑️ Clearing all cache manually...')
+  cache.flushAll()
+  console.log('✅ All cache cleared successfully (manually).')
+}
+
+/**
+ * Manual clearing of cache for languages only.
+ */
+export const clearLanguagesCache = async () => {
+  console.log('🗑️ Clearing cache for languages...')
+  cache.del('languages')
+  console.log('✅ Cache for languages cleared successfully.')
+}
+
+/**
+ * Manual clearing of cache for locations only.
+ */
+export const clearLocationsCache = async () => {
+  console.log('🗑️ Clearing cache for locations...')
+  cache.del('countries')
+  cache.delByPrefix('cities_')
+  console.log('✅ Cache for locations cleared successfully.')
+}

--- a/src/seed/manualClearCache.js
+++ b/src/seed/manualClearCache.js
@@ -1,0 +1,32 @@
+import { clearCacheManually, clearLanguagesCache, clearLocationsCache } from '#cron-jobs/clearCache.js'
+import { logger } from '#logger/logger.js'
+
+const manualClear = async () => {
+  const cacheType = process.argv[2]
+
+  try {
+    switch (cacheType) {
+    case 'all':
+      await clearCacheManually()
+      logger.info('All cache cleared successfully.')
+      break
+    case 'languages':
+      await clearLanguagesCache()
+      logger.info('Languages cache cleared successfully.')
+      break
+    case 'locations':
+      await clearLocationsCache()
+      logger.info('Locations cache cleared successfully.')
+      break
+    default:
+      logger.warn('Invalid cache type specified. Use "all", "languages", or "locations".')
+      process.exit(1)
+    }
+    process.exit(0)
+  } catch (error) {
+    logger.error(`Error while clearing cache (${cacheType}): ${error.message}`)
+    process.exit(1)
+  }
+}
+
+manualClear()

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -2,4 +2,14 @@ import NodeCache from 'node-cache'
 
 export const cache = new NodeCache({ stdTTL: 24 * 60 * 60, checkperiod: 60 * 60 })
 
+/**
+ * Delete all keys with a given prefix.
+ * @param {string} prefix - The prefix to match keys.
+ */
+cache.delByPrefix = (prefix) => {
+  const keys = cache.keys()
+  const keysToDelete = keys.filter((key) => key.startsWith(prefix))
+  keysToDelete.forEach((key) => cache.del(key))
+}
+
 export default cache


### PR DESCRIPTION
## Overview
This PR introduces functionality for manually clearing cache entries for specific cache types (`languages`, `locations`) or all cache at once. 

## Key Changes
- **New Commands**:
  - `npm run clear:cache:all`: Clears all cache entries in the system.
  - `npm run clear:cache:languages`: Clears only the cache entry for `languages`.
  - `npm run clear:cache:locations`: Clears cache entries for `countries` and `cities`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced cache management capabilities with new commands for clearing all caches or targeting languages and locations.
  - Added an automated process that clears all caches daily at midnight (UTC).

- **Documentation**
  - Updated user documentation with detailed instructions and safety guidelines for cache management, ensuring users understand how to execute cache clearing commands effectively in production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->